### PR TITLE
Update to featured image output to escape early

### DIFF
--- a/lib/genesis/blog-featured-image.php
+++ b/lib/genesis/blog-featured-image.php
@@ -9,6 +9,10 @@ function bolt_pro_foundation_featured_image() {
 	 * Outputs image as part of the post content, so it's included in the RSS feed.
 	 * H/t to Robin Cornett for the suggestion of making image available to RSS.
 	 */
+	
+	// Exit early
+	if ( has_post_thumbnail() == false )
+		return;
 
 	$image = '<div class="featured-image">';
 	$image .= get_the_post_thumbnail( get_the_ID(), 'full' );


### PR DESCRIPTION
Escape early if their is no featured image to avoid outputting empty markup.
Also consider adding a conditional check to avoid outputting on pages or rename the file to avoid using the word blog as it currently outputs on both posts and pages.